### PR TITLE
fix(BridgeManager): disable update operator

### DIFF
--- a/src/extensions/bridge-operator-governance/BridgeManager.sol
+++ b/src/extensions/bridge-operator-governance/BridgeManager.sol
@@ -118,31 +118,7 @@ abstract contract BridgeManager is IQuorum, IBridgeManager, BridgeManagerCallbac
    * their operator address blank null `address(0)`, consider add authorization check.
    */
   function updateBridgeOperator(address newBridgeOperator) external onlyGovernor {
-    _requireNonZeroAddress(newBridgeOperator);
-
-    // Queries the previous bridge operator
-    mapping(address => BridgeOperatorInfo) storage _gorvernorToBridgeOperatorInfo = _getGovernorToBridgeOperatorInfo();
-    address currentBridgeOperator = _gorvernorToBridgeOperatorInfo[msg.sender].addr;
-    if (currentBridgeOperator == newBridgeOperator) {
-      revert ErrBridgeOperatorAlreadyExisted(newBridgeOperator);
-    }
-
-    // Tries replace the bridge operator
-    EnumerableSet.AddressSet storage _bridgeOperatorSet = _getBridgeOperatorSet();
-    bool updated = _bridgeOperatorSet.remove(currentBridgeOperator) && _bridgeOperatorSet.add(newBridgeOperator);
-    if (!updated) revert ErrBridgeOperatorUpdateFailed(newBridgeOperator);
-
-    mapping(address => address) storage _governorOf = _getGovernorOf();
-    delete _governorOf[currentBridgeOperator];
-    _governorOf[newBridgeOperator] = msg.sender;
-    _gorvernorToBridgeOperatorInfo[msg.sender].addr = newBridgeOperator;
-
-    _notifyRegisters(
-      IBridgeManagerCallback.onBridgeOperatorUpdated.selector,
-      abi.encode(currentBridgeOperator, newBridgeOperator)
-    );
-
-    emit BridgeOperatorUpdated(msg.sender, currentBridgeOperator, newBridgeOperator);
+    revert("Not supported");
   }
 
   /**

--- a/test/bridge/unit/fuzz/bridge-manager/BridgeManagerCRUD.t.sol
+++ b/test/bridge/unit/fuzz/bridge-manager/BridgeManagerCRUD.t.sol
@@ -212,6 +212,7 @@ contract BridgeManagerCRUDTest is BridgeManagerUtils {
     uint256 r3,
     uint16 numBridgeOperators
   ) external virtual {
+    vm.skip(true);
     (address[] memory bridgeOperators, address[] memory governors, uint96[] memory voteWeights) = getValidInputs(
       r1,
       r2,


### PR DESCRIPTION
### Description
Disable update operator because improper handle in tracking will cause new operator could be slashed.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
