### PR TITLE
feat(*Gateway): support ERC721Batch, ERC1155Batch

### DIFF
--- a/script/20231218-maptoken/20231218-maptoken-mainchain.s.sol
+++ b/script/20231218-maptoken/20231218-maptoken-mainchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";
@@ -41,8 +41,8 @@ contract Migration__20231215_MapTokenMainchain is BridgeMigration {
     mainchainTokens[0] = _aggMainchainToken;
     address[] memory roninTokens = new address[](1);
     roninTokens[0] = _aggRoninToken;
-    Token.Standard[] memory standards = new Token.Standard[](1);
-    standards[0] = Token.Standard.ERC20;
+    TokenStandard[] memory standards = new TokenStandard[](1);
+    standards[0] = TokenStandard.ERC20;
     uint256[][4] memory thresholds;
     // highTierThreshold
     thresholds[0] = new uint256[](1);
@@ -60,7 +60,7 @@ contract Migration__20231215_MapTokenMainchain is BridgeMigration {
     // function mapTokensAndThresholds(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards,
+    //   TokenStandard[] calldata _standards,
     //   uint256[][4] calldata _thresholds
     // )
 

--- a/script/20231218-maptoken/20231218-maptoken-mainchain.s.sol
+++ b/script/20231218-maptoken/20231218-maptoken-mainchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";

--- a/script/20231218-maptoken/20231218-maptoken-roninchain.s.sol
+++ b/script/20231218-maptoken/20231218-maptoken-roninchain.s.sol
@@ -6,7 +6,7 @@ import { StdStyle } from "forge-std/StdStyle.sol";
 import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";
@@ -32,14 +32,14 @@ contract Migration__20231215_MapTokenRoninchain is BridgeMigration {
     mainchainTokens[0] = _aggMainchainToken;
     uint256[] memory chainIds = new uint256[](1);
     chainIds[0] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    Token.Standard[] memory standards = new Token.Standard[](1);
-    standards[0] = Token.Standard.ERC20;
+    TokenStandard[] memory standards = new TokenStandard[](1);
+    standards[0] = TokenStandard.ERC20;
 
     // function mapTokens(
     //   address[] calldata _roninTokens,
     //   address[] calldata _mainchainTokens,
     //   uint256[] calldata chainIds,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
     bytes memory innerData =
       abi.encodeCall(IRoninGatewayV3.mapTokens, (roninTokens, mainchainTokens, chainIds, standards));

--- a/script/20231218-maptoken/20231218-maptoken-roninchain.s.sol
+++ b/script/20231218-maptoken/20231218-maptoken-roninchain.s.sol
@@ -6,7 +6,7 @@ import { StdStyle } from "forge-std/StdStyle.sol";
 import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";

--- a/script/20240115-mappixeltoken/20240115-maptoken-mainchain.s.sol
+++ b/script/20240115-mappixeltoken/20240115-maptoken-mainchain.s.sol
@@ -8,7 +8,7 @@ import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeMa
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { IBridgeManager } from "@ronin/contracts/interfaces/bridge/IBridgeManager.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";

--- a/script/20240115-mappixeltoken/20240115-maptoken-mainchain.s.sol
+++ b/script/20240115-mappixeltoken/20240115-maptoken-mainchain.s.sol
@@ -8,7 +8,7 @@ import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeMa
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { IBridgeManager } from "@ronin/contracts/interfaces/bridge/IBridgeManager.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";
@@ -56,16 +56,16 @@ contract Migration__MapTokenMainchain is BridgeMigration {
   function _mapFarmlandToken() internal pure returns (bytes memory) {
     address[] memory mainchainTokens = new address[](1);
     address[] memory roninTokens = new address[](1);
-    Token.Standard[] memory standards = new Token.Standard[](1);
+    TokenStandard[] memory standards = new TokenStandard[](1);
 
     mainchainTokens[0] = _farmlandMainchainToken;
     roninTokens[0] = _farmlandRoninToken;
-    standards[0] = Token.Standard.ERC721;
+    standards[0] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
 
     bytes memory innerData = abi.encodeCall(IMainchainGatewayV3.mapTokens, (
@@ -79,7 +79,7 @@ contract Migration__MapTokenMainchain is BridgeMigration {
   function _mapPixelToken() internal pure returns (bytes memory) {
     address[] memory mainchainTokens = new address[](1);
     address[] memory roninTokens = new address[](1);
-    Token.Standard[] memory standards = new Token.Standard[](1);
+    TokenStandard[] memory standards = new TokenStandard[](1);
     uint256[][4] memory thresholds;
 
     // highTierThreshold
@@ -97,12 +97,12 @@ contract Migration__MapTokenMainchain is BridgeMigration {
 
     mainchainTokens[0] = _farmlandMainchainToken;
     roninTokens[0] = _farmlandRoninToken;
-    standards[0] = Token.Standard.ERC20;
+    standards[0] = TokenStandard.ERC20;
 
     // function mapTokensAndThresholds(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards,
+    //   TokenStandard[] calldata _standards,
     //   uint256[][4] calldata _thresholds
     // )
 

--- a/script/20240115-mappixeltoken/20240115-maptoken-roninchain.s.sol
+++ b/script/20240115-mappixeltoken/20240115-maptoken-roninchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
 import { IBridgeManager } from "@ronin/contracts/interfaces/bridge/IBridgeManager.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";

--- a/script/20240115-mappixeltoken/20240115-maptoken-roninchain.s.sol
+++ b/script/20240115-mappixeltoken/20240115-maptoken-roninchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
 import { IBridgeManager } from "@ronin/contracts/interfaces/bridge/IBridgeManager.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";
@@ -40,23 +40,23 @@ contract Migration__MapTokenRoninchain is BridgeMigration {
     address[] memory mainchainTokens = new address[](2);
     address[] memory roninTokens = new address[](2);
     uint256[] memory chainIds = new uint256[](2);
-    Token.Standard[] memory standards = new Token.Standard[](2);
+    TokenStandard[] memory standards = new TokenStandard[](2);
 
     mainchainTokens[0] = _farmlandMainchainToken;
     roninTokens[0] = _farmlandRoninToken;
     chainIds[0] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[0] = Token.Standard.ERC721;
+    standards[0] = TokenStandard.ERC721;
 
     mainchainTokens[1] = _pixelMainchainToken;
     roninTokens[1] = _pixelRoninToken;
     chainIds[1] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[1] = Token.Standard.ERC20;
+    standards[1] = TokenStandard.ERC20;
 
     // function mapTokens(
     //   address[] calldata _roninTokens,
     //   address[] calldata _mainchainTokens,
     //   uint256[] calldata chainIds,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
 
     bytes memory innerData = abi.encodeCall(IRoninGatewayV3.mapTokens, (

--- a/script/20240131-maptoken-pixel/20240131-maptoken-pixel-mainchain.s.sol
+++ b/script/20240131-maptoken-pixel/20240131-maptoken-pixel-mainchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";
@@ -39,7 +39,7 @@ contract Migration__20240131_MapTokenPixelMainchain is BridgeMigration, Migratio
   function run() public {
     address[] memory mainchainTokens = new address[](1);
     address[] memory roninTokens = new address[](1);
-    Token.Standard[] memory standards = new Token.Standard[](1);
+    TokenStandard[] memory standards = new TokenStandard[](1);
     uint256[][4] memory thresholds;
 
     uint256 expiredTime = block.timestamp + 10 days;
@@ -52,7 +52,7 @@ contract Migration__20240131_MapTokenPixelMainchain is BridgeMigration, Migratio
 
     mainchainTokens[0] = _pixelMainchainToken;
     roninTokens[0] = _pixelRoninToken;
-    standards[0] = Token.Standard.ERC20;
+    standards[0] = TokenStandard.ERC20;
     // highTierThreshold
     thresholds[0] = new uint256[](1);
     thresholds[0][0] = _highTierThreshold;
@@ -69,7 +69,7 @@ contract Migration__20240131_MapTokenPixelMainchain is BridgeMigration, Migratio
     // function mapTokensAndThresholds(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards,
+    //   TokenStandard[] calldata _standards,
     //   uint256[][4] calldata _thresholds
     // )
 
@@ -91,12 +91,12 @@ contract Migration__20240131_MapTokenPixelMainchain is BridgeMigration, Migratio
 
     mainchainTokens[0] = _farmlandMainchainToken;
     roninTokens[0] = _farmlandRoninToken;
-    standards[0] = Token.Standard.ERC721;
+    standards[0] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // ) external;
 
     innerData = abi.encodeCall(IMainchainGatewayV3.mapTokens, (

--- a/script/20240131-maptoken-pixel/20240131-maptoken-pixel-mainchain.s.sol
+++ b/script/20240131-maptoken-pixel/20240131-maptoken-pixel-mainchain.s.sol
@@ -7,7 +7,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Contract } from "../utils/Contract.sol";
 import { BridgeMigration } from "../BridgeMigration.sol";
 import { Network } from "../utils/Network.sol";

--- a/script/20240131-maptoken-pixel/20240131-maptoken-pixel-roninchain.s.sol
+++ b/script/20240131-maptoken-pixel/20240131-maptoken-pixel-roninchain.s.sol
@@ -8,7 +8,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
 import { MinimumWithdrawal } from "@ronin/contracts/extensions/MinimumWithdrawal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 
@@ -48,7 +48,7 @@ contract Migration__20240131_MapTokenPixelRoninchain is BridgeMigration, Migrati
     address[] memory roninTokens = new address[](2);
     address[] memory mainchainTokens = new address[](2);
     uint256[] memory chainIds = new uint256[](2);
-    Token.Standard[] memory standards = new Token.Standard[](2);
+    TokenStandard[] memory standards = new TokenStandard[](2);
 
     uint256 expiredTime = block.timestamp + 10 days;
     address[] memory targets = new address[](4);
@@ -61,18 +61,18 @@ contract Migration__20240131_MapTokenPixelRoninchain is BridgeMigration, Migrati
     roninTokens[0] = _pixelRoninToken;
     mainchainTokens[0] = _pixelMainchainToken;
     chainIds[0] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[0] = Token.Standard.ERC20;
+    standards[0] = TokenStandard.ERC20;
 
     roninTokens[1] = _farmlandRoninToken;
     mainchainTokens[1] = _farmlandMainchainToken;
     chainIds[1] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[1] = Token.Standard.ERC721;
+    standards[1] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _roninTokens,
     //   address[] calldata _mainchainTokens,
     //   uint256[] calldata chainIds,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
     bytes memory innerData = abi.encodeCall(IRoninGatewayV3.mapTokens, (
       roninTokens,

--- a/script/20240131-maptoken-pixel/20240131-maptoken-pixel-roninchain.s.sol
+++ b/script/20240131-maptoken-pixel/20240131-maptoken-pixel-roninchain.s.sol
@@ -8,7 +8,7 @@ import { BaseMigration } from "foundry-deployment-kit/BaseMigration.s.sol";
 import { RoninBridgeManager } from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import { IRoninGatewayV3 } from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
 import { MinimumWithdrawal } from "@ronin/contracts/extensions/MinimumWithdrawal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 

--- a/script/20240206-maptoken-banana/20240206-maptoken-banana-mainchain.s.sol
+++ b/script/20240206-maptoken-banana/20240206-maptoken-banana-mainchain.s.sol
@@ -7,7 +7,7 @@ import {BaseMigration} from "foundry-deployment-kit/BaseMigration.s.sol";
 import {RoninBridgeManager} from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import {IMainchainGatewayV3} from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import {GlobalProposal} from "@ronin/contracts/libraries/GlobalProposal.sol";
-import {Token} from "@ronin/contracts/libraries/Token.sol";
+import {LibTokenInfo, TokenStandard} from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import {Contract} from "../utils/Contract.sol";
 import {BridgeMigration} from "../BridgeMigration.sol";
 import {Network} from "../utils/Network.sol";
@@ -43,7 +43,7 @@ contract Migration__20240206_MapTokenBananaMainchain is
   function run() public onlyOn(DefaultNetwork.RoninMainnet.key()) {
     address[] memory mainchainTokens = new address[](1);
     address[] memory roninTokens = new address[](1);
-    Token.Standard[] memory standards = new Token.Standard[](1);
+    TokenStandard[] memory standards = new TokenStandard[](1);
     uint256[][4] memory thresholds;
 
     uint256 expiredTime = block.timestamp + 10 days;
@@ -56,7 +56,7 @@ contract Migration__20240206_MapTokenBananaMainchain is
 
     mainchainTokens[0] = _bananaMainchainToken;
     roninTokens[0] = _bananaRoninToken;
-    standards[0] = Token.Standard.ERC20;
+    standards[0] = TokenStandard.ERC20;
     // highTierThreshold
     thresholds[0] = new uint256[](1);
     thresholds[0][0] = _highTierThreshold;
@@ -73,7 +73,7 @@ contract Migration__20240206_MapTokenBananaMainchain is
     // function mapTokens(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
 
     bytes memory innerData = abi.encodeCall(IMainchainGatewayV3.mapTokensAndThresholds, (mainchainTokens, roninTokens, standards, thresholds));
@@ -89,12 +89,12 @@ contract Migration__20240206_MapTokenBananaMainchain is
 
     mainchainTokens[0] = _genkaiMainchainToken;
     roninTokens[0] = _genkaiRoninToken;
-    standards[0] = Token.Standard.ERC721;
+    standards[0] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // ) external;
 
     innerData = abi.encodeCall(IMainchainGatewayV3.mapTokens, (mainchainTokens, roninTokens, standards));
@@ -110,12 +110,12 @@ contract Migration__20240206_MapTokenBananaMainchain is
 
     mainchainTokens[0] = _VxMainchainToken;
     roninTokens[0] = _VxRoninToken;
-    standards[0] = Token.Standard.ERC721;
+    standards[0] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _mainchainTokens,
     //   address[] calldata _roninTokens,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // ) external;
 
     innerData = abi.encodeCall(IMainchainGatewayV3.mapTokens, (mainchainTokens, roninTokens, standards));

--- a/script/20240206-maptoken-banana/20240206-maptoken-banana-roninchain.s.sol
+++ b/script/20240206-maptoken-banana/20240206-maptoken-banana-roninchain.s.sol
@@ -9,7 +9,7 @@ import {DefaultNetwork} from "foundry-deployment-kit/utils/DefaultNetwork.sol";
 import {RoninBridgeManager} from "@ronin/contracts/ronin/gateway/RoninBridgeManager.sol";
 import {IRoninGatewayV3} from "@ronin/contracts/interfaces/IRoninGatewayV3.sol";
 import {MinimumWithdrawal} from "@ronin/contracts/extensions/MinimumWithdrawal.sol";
-import {Token} from "@ronin/contracts/libraries/Token.sol";
+import {LibTokenInfo, TokenStandard} from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import {Ballot} from "@ronin/contracts/libraries/Ballot.sol";
 import {GlobalProposal} from "@ronin/contracts/libraries/GlobalProposal.sol";
 import {Proposal} from "@ronin/contracts/libraries/Proposal.sol";
@@ -64,7 +64,7 @@ contract Migration__20240206_MapTokenBananaRoninChain is
     address[] memory roninTokens = new address[](3);
     address[] memory mainchainTokens = new address[](3);
     uint256[] memory chainIds = new uint256[](3);
-    Token.Standard[] memory standards = new Token.Standard[](3);
+    TokenStandard[] memory standards = new TokenStandard[](3);
 
     uint256 expiredTime = block.timestamp + 10 days;
     address[] memory targets = new address[](4);
@@ -77,23 +77,23 @@ contract Migration__20240206_MapTokenBananaRoninChain is
     roninTokens[0] = _bananaRoninToken;
     mainchainTokens[0] = _bananaMainchainToken;
     chainIds[0] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[0] = Token.Standard.ERC20;
+    standards[0] = TokenStandard.ERC20;
 
     roninTokens[1] = _VxRoninToken;
     mainchainTokens[1] = _VxMainchainToken;
     chainIds[1] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[1] = Token.Standard.ERC721;
+    standards[1] = TokenStandard.ERC721;
 
     roninTokens[2] = _genkaiRoninToken;
     mainchainTokens[2] = _genkaiMainchainToken;
     chainIds[2] = _config.getCompanionNetwork(_config.getNetworkByChainId(block.chainid)).chainId();
-    standards[2] = Token.Standard.ERC721;
+    standards[2] = TokenStandard.ERC721;
 
     // function mapTokens(
     //   address[] calldata _roninTokens,
     //   address[] calldata _mainchainTokens,
     //   uint256[] calldata chainIds,
-    //   Token.Standard[] calldata _standards
+    //   TokenStandard[] calldata _standards
     // )
     bytes memory innerData =
       abi.encodeCall(IRoninGatewayV3.mapTokens, (roninTokens, mainchainTokens, chainIds, standards));
@@ -117,7 +117,7 @@ contract Migration__20240206_MapTokenBananaRoninChain is
 
     roninTokensToSetMinThreshold[1] = pixelRoninToken;
     minThresholds[1] = pixelMinThreshold;
-    
+
     roninTokensToSetMinThreshold[2] = pixelMainchainToken;
     minThresholds[2] = 0;
 

--- a/script/Migration.s.sol
+++ b/script/Migration.s.sol
@@ -9,7 +9,7 @@ import { Network } from "./utils/Network.sol";
 import { Utils } from "./utils/Utils.sol";
 import { Contract } from "./utils/Contract.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { LibArray } from "./libraries/LibArray.sol";
 
 contract Migration is BaseMigrationV2, Utils {

--- a/script/Migration.s.sol
+++ b/script/Migration.s.sol
@@ -9,7 +9,7 @@ import { Network } from "./utils/Network.sol";
 import { Utils } from "./utils/Utils.sol";
 import { Contract } from "./utils/Contract.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { LibArray } from "./libraries/LibArray.sol";
 
 contract Migration is BaseMigrationV2, Utils {

--- a/script/interfaces/ISharedArgument.sol
+++ b/script/interfaces/ISharedArgument.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { IGeneralConfig } from "foundry-deployment-kit/interfaces/IGeneralConfig.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 
 interface ISharedArgument is IGeneralConfig {
   struct BridgeManagerParam {
@@ -36,7 +36,7 @@ interface ISharedArgument is IGeneralConfig {
     // thresholds[2]: unlockFeePercentages
     // thresholds[3]: dailyWithdrawalLimit
     uint256[][4] thresholds;
-    Token.Standard[] standards;
+    TokenStandard[] standards;
   }
 
   struct RoninGatewayV3Param {
@@ -52,7 +52,7 @@ interface ISharedArgument is IGeneralConfig {
     // packedNumbers[0]: chainIds
     // packedNumbers[1]: minimumThresholds
     uint256[][2] packedNumbers;
-    Token.Standard[] standards;
+    TokenStandard[] standards;
   }
 
   struct BridgeSlashParam {

--- a/script/interfaces/ISharedArgument.sol
+++ b/script/interfaces/ISharedArgument.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.23;
 
 import { IGeneralConfig } from "foundry-deployment-kit/interfaces/IGeneralConfig.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 
 interface ISharedArgument is IGeneralConfig {
   struct BridgeManagerParam {

--- a/src/extensions/MinimumWithdrawal.sol
+++ b/src/extensions/MinimumWithdrawal.sol
@@ -61,7 +61,7 @@ abstract contract MinimumWithdrawal is HasProxyAdmin {
    * @dev Checks whether the request is larger than or equal to the minimum threshold.
    */
   function _checkWithdrawal(Transfer.Request calldata _request) internal view {
-    if (_request.info.erc == Token.Standard.ERC20 && _request.info.quantity < minimumThreshold[_request.tokenAddr]) {
+    if (_request.info.erc == TokenStandard.ERC20 && _request.info.quantity < minimumThreshold[_request.tokenAddr]) {
       revert ErrQueryForTooSmallQuantity();
     }
   }

--- a/src/interfaces/IMainchainGatewayV3.sol
+++ b/src/interfaces/IMainchainGatewayV3.sol
@@ -28,17 +28,17 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   error ErrQueryForInsufficientVoteWeight();
 
   /// @dev Emitted when the deposit is requested
-  event DepositRequested(bytes32 receiptHash, Transfer.Receipt receipt);
+  event DepositRequested(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
   /// @dev Emitted when the assets are withdrawn
-  event Withdrew(bytes32 receiptHash, Transfer.Receipt receipt);
+  event Withdrew(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
   /// @dev Emitted when the tokens are mapped
   event TokenMapped(address[] mainchainTokens, address[] roninTokens, TokenStandard[] standards);
   /// @dev Emitted when the wrapped native token contract is updated
   event WrappedNativeTokenContractUpdated(IWETH weth);
   /// @dev Emitted when the withdrawal is locked
-  event WithdrawalLocked(bytes32 receiptHash, Transfer.Receipt receipt);
+  event WithdrawalLocked(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
   /// @dev Emitted when the withdrawal is unlocked
-  event WithdrawalUnlocked(bytes32 receiptHash, Transfer.Receipt receipt);
+  event WithdrawalUnlocked(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
 
   /**
    * @dev Returns the domain seperator.

--- a/src/interfaces/IMainchainGatewayV3.sol
+++ b/src/interfaces/IMainchainGatewayV3.sol
@@ -32,7 +32,7 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   /// @dev Emitted when the assets are withdrawn
   event Withdrew(bytes32 receiptHash, Transfer.Receipt receipt);
   /// @dev Emitted when the tokens are mapped
-  event TokenMapped(address[] mainchainTokens, address[] roninTokens, Token.Standard[] standards);
+  event TokenMapped(address[] mainchainTokens, address[] roninTokens, TokenStandard[] standards);
   /// @dev Emitted when the wrapped native token contract is updated
   event WrappedNativeTokenContractUpdated(IWETH weth);
   /// @dev Emitted when the withdrawal is locked
@@ -112,7 +112,7 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   function mapTokens(
     address[] calldata _mainchainTokens,
     address[] calldata _roninTokens,
-    Token.Standard[] calldata _standards
+    TokenStandard[] calldata _standards
   ) external;
 
   /**
@@ -128,7 +128,7 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   function mapTokensAndThresholds(
     address[] calldata _mainchainTokens,
     address[] calldata _roninTokens,
-    Token.Standard[] calldata _standards,
+    TokenStandard[] calldata _standards,
     uint256[][4] calldata _thresholds
   ) external;
 

--- a/src/interfaces/IRoninGatewayV3.sol
+++ b/src/interfaces/IRoninGatewayV3.sol
@@ -21,13 +21,13 @@ interface IRoninGatewayV3 is MappedTokenConsumer {
   error ErrWithdrawnOnMainchainAlready();
 
   /// @dev Emitted when the assets are depositted
-  event Deposited(bytes32 receiptHash, Transfer.Receipt receipt);
+  event Deposited(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
   /// @dev Emitted when the withdrawal is requested
-  event WithdrawalRequested(bytes32 receiptHash, Transfer.Receipt);
+  event WithdrawalRequested(bytes32 receiptHash, Transfer.ReceiptManifest);
   /// @dev Emitted when the assets are withdrawn on mainchain
-  event MainchainWithdrew(bytes32 receiptHash, Transfer.Receipt receipt);
+  event MainchainWithdrew(bytes32 receiptHash, Transfer.ReceiptManifest receipt);
   /// @dev Emitted when the withdrawal signatures is requested
-  event WithdrawalSignaturesRequested(bytes32 receiptHash, Transfer.Receipt);
+  event WithdrawalSignaturesRequested(bytes32 receiptHash, Transfer.ReceiptManifest);
   /// @dev Emitted when the tokens are mapped
   event TokenMapped(address[] roninTokens, address[] mainchainTokens, uint256[] chainIds, TokenStandard[] standards);
   /// @dev Emitted when the threshold is updated

--- a/src/interfaces/IRoninGatewayV3.sol
+++ b/src/interfaces/IRoninGatewayV3.sol
@@ -29,7 +29,7 @@ interface IRoninGatewayV3 is MappedTokenConsumer {
   /// @dev Emitted when the withdrawal signatures is requested
   event WithdrawalSignaturesRequested(bytes32 receiptHash, Transfer.Receipt);
   /// @dev Emitted when the tokens are mapped
-  event TokenMapped(address[] roninTokens, address[] mainchainTokens, uint256[] chainIds, Token.Standard[] standards);
+  event TokenMapped(address[] roninTokens, address[] mainchainTokens, uint256[] chainIds, TokenStandard[] standards);
   /// @dev Emitted when the threshold is updated
   event TrustedThresholdUpdated(
     uint256 indexed nonce,
@@ -144,7 +144,7 @@ interface IRoninGatewayV3 is MappedTokenConsumer {
     address[] calldata _roninTokens,
     address[] calldata _mainchainTokens,
     uint256[] calldata chainIds,
-    Token.Standard[] calldata _standards
+    TokenStandard[] calldata _standards
   ) external;
 
   /**

--- a/src/interfaces/consumers/MappedTokenConsumer.sol
+++ b/src/interfaces/consumers/MappedTokenConsumer.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../../libraries/Token.sol";
+import "../../libraries/LibTokenInfo.sol";
 
 interface MappedTokenConsumer {
   struct MappedToken {
-    Token.Standard erc;
+    TokenStandard erc;
     address tokenAddr;
   }
 }

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -16,6 +16,8 @@ struct TokenInfo {
   // For ERC721: the quantity must be 0.
   uint256 id;
   uint256 quantity;
+  uint256[] ids;
+  uint256[] quantities;
 }
 
 library LibTokenInfo {

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -101,7 +101,7 @@ library LibTokenInfo {
 
   function _hashSingle(TokenInfo memory self) internal pure returns (bytes32 digest) {
     // return keccak256(abi.encode(INFO_TYPE_HASH_SINGLE, self.erc, self.id, self.quantity));
-    assembly {
+    assembly ("memory-safe") {
       let ptr := mload(0x40)
       mstore(ptr, INFO_TYPE_HASH_SINGLE)
       mstore(add(ptr, 0x20), mload(self)) // info.erc
@@ -115,7 +115,7 @@ library LibTokenInfo {
     bytes32 idsHash = keccak256(abi.encode(self.ids));
     bytes32 qtysHash = keccak256(abi.encode(self.quantities));
 
-    assembly {
+    assembly ("memory-safe") {
       let ptr := mload(0x40)
       mstore(ptr, INFO_TYPE_HASH_SINGLE)
       mstore(add(ptr, 0x20), mload(self)) // info.erc

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -195,8 +195,7 @@ library LibTokenInfo {
         token.call(abi.encodeWithSelector(IERC20.transferFrom.selector, from, address(this), self.quantity));
       success = success && (data.length == 0 || abi.decode(data, (bool)));
     } else if (self.erc == TokenStandard.ERC721) {
-      // bytes4(keccak256("transferFrom(address,address,uint256)"))
-      (success,) = token.call(abi.encodeWithSelector(0x23b872dd, from, address(this), self.id));
+      success = _tryTransferFromERC721(token, from, address(this), self.id);
     } else if (self.erc == TokenStandard.ERC1155Batch) {
       success = _tryTransferERC1155Batch(token, from, address(this), self.ids, self.quantities);
     } else {

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -213,21 +213,30 @@ library LibTokenInfo {
         wrappedNativeToken.deposit{ value: self.quantity }();
         _transfer(self, to, token);
       }
-    } else if (self.erc == TokenStandard.ERC20) {
-      uint256 _balance = IERC20(token).balanceOf(address(this));
 
-      if (_balance < self.quantity) {
-        if (!_tryMintERC20(token, address(this), self.quantity - _balance)) revert ErrERC20MintingFailed();
+      return;
+    }
+
+    if (self.erc == TokenStandard.ERC20) {
+      uint256 balance = IERC20(token).balanceOf(address(this));
+      if (balance < self.quantity) {
+        if (!_tryMintERC20(token, address(this), self.quantity - balance)) revert ErrERC20MintingFailed();
       }
 
       _transfer(self, to, token);
-    } else if (self.erc == TokenStandard.ERC721) {
+
+      return;
+    }
+
+    if (self.erc == TokenStandard.ERC721) {
       if (!_tryTransferERC721(token, to, self.id)) {
         if (!_tryMintERC721(token, to, self.id)) revert ErrERC721MintingFailed();
       }
-    } else {
-      revert ErrUnsupportedStandard();
+
+      return;
     }
+
+    revert ErrUnsupportedStandard();
   }
 
   /**

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -135,7 +135,7 @@ library LibTokenInfo {
    * @dev Validates the token info.
    */
   function validate(TokenInfo memory self) internal pure {
-    if (!(_validateERC20(self) || _validateERC721(self)) || _validateERC721Batch(self) || _validateERC1155Batch(self)) {
+    if (!(_validateERC20(self) || _validateERC721(self) || _validateERC721Batch(self) || _validateERC1155Batch(self))) {
       revert ErrInvalidInfo();
     }
   }

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -140,7 +140,7 @@ library LibTokenInfo {
 
   function _validate(TokenInfo memory self) private pure returns (bool passed) {
     if (_isModeSingle(self.mode)) {
-      return _validateERC20(self) || _validateERC721(self);
+      return _validateERC20(self) || _validateERC721(self) || _validateERC1155(self);
     }
 
     if (_isModeBatch(self.mode)) {

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -172,14 +172,14 @@ library LibTokenInfo {
   /**
    * @dev Transfers ERC721 token and returns the result.
    */
-  function tryTransferERC721(address token, address to, uint256 id) internal returns (bool success) {
+  function _tryTransferERC721(address token, address to, uint256 id) private returns (bool success) {
     (success,) = token.call(abi.encodeWithSelector(IERC721.transferFrom.selector, address(this), to, id));
   }
 
   /**
    * @dev Transfers ERC20 token and returns the result.
    */
-  function tryTransferERC20(address token, address to, uint256 quantity) internal returns (bool success) {
+  function _tryTransferERC20(address token, address to, uint256 quantity) private returns (bool success) {
     bytes memory data;
     (success, data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, quantity));
     success = success && (data.length == 0 || abi.decode(data, (bool)));
@@ -191,9 +191,9 @@ library LibTokenInfo {
   function transfer(TokenInfo memory self, address to, address token) internal {
     bool success;
     if (self.erc == TokenStandard.ERC20) {
-      success = tryTransferERC20(token, to, self.quantity);
+      success = _tryTransferERC20(token, to, self.quantity);
     } else if (self.erc == TokenStandard.ERC721) {
-      success = tryTransferERC721(token, to, self.id);
+      success = _tryTransferERC721(token, to, self.id);
     } else {
       revert ErrUnsupportedStandard();
     }
@@ -228,7 +228,7 @@ library LibTokenInfo {
 
       transfer(self, to, token);
     } else if (self.erc == TokenStandard.ERC721) {
-      if (!tryTransferERC721(token, to, self.id)) {
+      if (!_tryTransferERC721(token, to, self.id)) {
         // bytes4(keccak256("mint(address,uint256)"))
         (success,) = token.call(abi.encodeWithSelector(0x40c10f19, to, self.id));
         if (!success) revert ErrERC721MintingFailed();

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -112,8 +112,8 @@ library LibTokenInfo {
   }
 
   function _hashBatch(TokenInfo memory self) internal pure returns (bytes32 digest) {
-    bytes32 idsHash = keccak256(abi.encode(self.ids));
-    bytes32 qtysHash = keccak256(abi.encode(self.quantities));
+    bytes32 idsHash = keccak256(abi.encodePacked(self.ids));
+    bytes32 qtysHash = keccak256(abi.encodePacked(self.quantities));
 
     assembly ("memory-safe") {
       let ptr := mload(0x40)

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -85,10 +85,10 @@ library LibTokenInfo {
    */
 
   // keccak256("TokenInfo(uint8 erc,uint256 id,uint256 quantity)");
-  bytes32 public constant INFO_TYPE_HASH_SINGLE = 0x1e2b74b2a792d5c0f0b6e59b037fa9d43d84fbb759337f0112fcc15ca414fc8d;
+  bytes32 internal constant INFO_TYPE_HASH_SINGLE = 0x1e2b74b2a792d5c0f0b6e59b037fa9d43d84fbb759337f0112fcc15ca414fc8d;
 
   // keccak256("TokenInfo(uint8 erc,uint256[] ids,uint256[] quantities)");
-  bytes32 public constant INFO_TYPE_HASH_BATCH = 0xe0d9a8bb18cfc29aa6e46b1293275ca79aeaaf28ac63b66dcb6ebce2f127f5a0;
+  bytes32 internal constant INFO_TYPE_HASH_BATCH = 0xe0d9a8bb18cfc29aa6e46b1293275ca79aeaaf28ac63b66dcb6ebce2f127f5a0;
 
   /**
    * @dev Returns token info struct hash.

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -34,8 +34,10 @@ library LibTokenInfo {
   /// @dev Error indicating that the minting of ERC721 tokens has failed.
   error ErrERC721MintingFailed();
 
-  /// @dev Error indicating that the transfer of ERC1155 tokens in batch has failed.
+  /// @dev Error indicating that the transfer of ERC1155 tokens has failed.
   error ErrERC1155TransferFailed();
+
+  /// @dev Error indicating that the mint of ERC1155 tokens in batch has failed.
   error ErrERC1155MintBatchFailed();
 
   /// @dev Error indicating that an unsupported standard is encountered.
@@ -80,7 +82,7 @@ library LibTokenInfo {
   // keccak256("TokenInfo(uint8 erc,uint256 id,uint256 quantity)");
   bytes32 public constant INFO_TYPE_HASH_SINGLE = 0x1e2b74b2a792d5c0f0b6e59b037fa9d43d84fbb759337f0112fcc15ca414fc8d;
 
-  // keccak256("TokenInfo(uint8 erc,uint256[] id,uint256[] quantity)");
+  // keccak256("TokenInfo(uint8 erc,uint256[] ids,uint256[] quantities)");
   bytes32 public constant INFO_TYPE_HASH_BATCH = 0xe0d9a8bb18cfc29aa6e46b1293275ca79aeaaf28ac63b66dcb6ebce2f127f5a0;
 
   /**
@@ -176,12 +178,12 @@ library LibTokenInfo {
 
   /**
    *
-   *       TRANSFER
+   *       TRANSFER IN/OUT METHOD
    *
    */
 
   /**
-   * @dev Transfer asset from.
+   * @dev Transfer asset in.
    *
    * Requirements:
    * - The `_from` address must approve for the contract using this library.
@@ -208,7 +210,7 @@ library LibTokenInfo {
   }
 
   /**
-   * @dev Tries minting and transfering assets.
+   * @dev Tries transfer assets out, or mint the assets if cannot transfer.
    *
    * @notice Prioritizes transfer native token if the token is wrapped.
    *

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -56,6 +56,25 @@ library LibTokenInfo {
   bytes32 public constant INFO_TYPE_HASH = 0x1e2b74b2a792d5c0f0b6e59b037fa9d43d84fbb759337f0112fcc15ca414fc8d;
 
   /**
+   *
+   *        ROUTER
+   *
+   */
+  function _isStandardSingle(TokenStandard standard) private pure returns (bool) {
+    return standard == TokenStandard.ERC20 || standard == TokenStandard.ERC721;
+  }
+
+  function _isStandardBatch(TokenStandard standard) private pure returns (bool) {
+    return standard == TokenStandard.ERC721Batch || standard == TokenStandard.ERC1155;
+  }
+
+  /**
+   *
+   *        HASH
+   *
+   */
+
+  /**
    * @dev Returns token info struct hash.
    */
   function hash(TokenInfo memory self) internal pure returns (bytes32 digest) {

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -198,22 +198,6 @@ library LibTokenInfo {
   }
 
   /**
-   * @dev Transfers ERC721 token and returns the result.
-   */
-  function _tryTransferERC721(address token, address to, uint256 id) private returns (bool success) {
-    (success,) = token.call(abi.encodeWithSelector(IERC721.transferFrom.selector, address(this), to, id));
-  }
-
-  /**
-   * @dev Transfers ERC20 token and returns the result.
-   */
-  function _tryTransferERC20(address token, address to, uint256 quantity) private returns (bool success) {
-    bytes memory data;
-    (success, data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, quantity));
-    success = success && (data.length == 0 || abi.decode(data, (bool)));
-  }
-
-  /**
    * @dev Transfer assets from current address to `_to` address.
    */
   function transfer(TokenInfo memory self, address to, address token) internal {
@@ -264,5 +248,27 @@ library LibTokenInfo {
     } else {
       revert ErrUnsupportedStandard();
     }
+  }
+
+  /**
+   *
+   *      TRANSFER HELPERS
+   *
+   */
+
+  /**
+   * @dev Transfers ERC721 token and returns the result.
+   */
+  function _tryTransferERC721(address token, address to, uint256 id) private returns (bool success) {
+    (success,) = token.call(abi.encodeWithSelector(IERC721.transferFrom.selector, address(this), to, id));
+  }
+
+  /**
+   * @dev Transfers ERC20 token and returns the result.
+   */
+  function _tryTransferERC20(address token, address to, uint256 quantity) private returns (bool success) {
+    bytes memory data;
+    (success, data) = token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, quantity));
+    success = success && (data.length == 0 || abi.decode(data, (bool)));
   }
 }

--- a/src/libraries/LibTokenInfo.sol
+++ b/src/libraries/LibTokenInfo.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "../interfaces/IWETH.sol";
 
 enum TokenStandard {
   ERC20,
   ERC721,
   ERC721Batch,
-  ERC1155
+  ERC1155Batch
 }
 
 struct TokenInfo {
@@ -62,7 +63,7 @@ library LibTokenInfo {
   }
 
   function _isStandardBatch(TokenStandard standard) private pure returns (bool) {
-    return standard == TokenStandard.ERC721Batch || standard == TokenStandard.ERC1155;
+    return standard == TokenStandard.ERC721Batch || standard == TokenStandard.ERC1155Batch;
   }
 
   /**
@@ -127,7 +128,7 @@ library LibTokenInfo {
    * @dev Validates the token info.
    */
   function validate(TokenInfo memory self) internal pure {
-    if (!(_validateERC20(self) || _validateERC721(self)) || _validateERC721Batch(self) || _validateERC1155(self)) {
+    if (!(_validateERC20(self) || _validateERC721(self)) || _validateERC721Batch(self) || _validateERC1155Batch(self)) {
       revert ErrInvalidInfo();
     }
   }
@@ -152,9 +153,9 @@ library LibTokenInfo {
     }
   }
 
-  function _validateERC1155(TokenInfo memory self) private pure returns (bool res) {
+  function _validateERC1155Batch(TokenInfo memory self) private pure returns (bool res) {
     uint256 length = self.ids.length;
-    res = self.erc == TokenStandard.ERC1155 && _validateBatch(self);
+    res = self.erc == TokenStandard.ERC1155Batch && _validateBatch(self);
 
     for (uint256 i; i < length; ++i) {
       if (self.quantities[i] == 0) {

--- a/src/libraries/LibTokenOwner.sol
+++ b/src/libraries/LibTokenOwner.sol
@@ -9,7 +9,7 @@ struct TokenOwner {
 
 library LibTokenOwner {
   // keccak256("TokenOwner(address addr,address tokenAddr,uint256 chainId)");
-  bytes32 public constant OWNER_TYPE_HASH = 0x353bdd8d69b9e3185b3972e08b03845c0c14a21a390215302776a7a34b0e8764;
+  bytes32 internal constant OWNER_TYPE_HASH = 0x353bdd8d69b9e3185b3972e08b03845c0c14a21a390215302776a7a34b0e8764;
 
   /**
    * @dev Returns ownership struct hash.

--- a/src/libraries/LibTokenOwner.sol
+++ b/src/libraries/LibTokenOwner.sol
@@ -15,7 +15,7 @@ library LibTokenOwner {
    * @dev Returns ownership struct hash.
    */
   function hash(TokenOwner memory owner) internal pure returns (bytes32 digest) {
-    // keccak256(abi.encode(OWNER_TYPE_HASH, owner.addr, owner.tokenAddr, owner.chainId))
+    // return keccak256(abi.encode(OWNER_TYPE_HASH, owner.addr, owner.tokenAddr, owner.chainId));
     assembly {
       let ptr := mload(0x40)
       mstore(ptr, OWNER_TYPE_HASH)

--- a/src/libraries/LibTokenOwner.sol
+++ b/src/libraries/LibTokenOwner.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct TokenOwner {
+  address addr;
+  address tokenAddr;
+  uint256 chainId;
+}
+
+library LibTokenOwner {
+  // keccak256("TokenOwner(address addr,address tokenAddr,uint256 chainId)");
+  bytes32 public constant OWNER_TYPE_HASH = 0x353bdd8d69b9e3185b3972e08b03845c0c14a21a390215302776a7a34b0e8764;
+
+  /**
+   * @dev Returns ownership struct hash.
+   */
+  function hash(TokenOwner memory owner) internal pure returns (bytes32 digest) {
+    // keccak256(abi.encode(OWNER_TYPE_HASH, owner.addr, owner.tokenAddr, owner.chainId))
+    assembly {
+      let ptr := mload(0x40)
+      mstore(ptr, OWNER_TYPE_HASH)
+      mstore(add(ptr, 0x20), mload(owner)) // owner.addr
+      mstore(add(ptr, 0x40), mload(add(owner, 0x20))) // owner.tokenAddr
+      mstore(add(ptr, 0x60), mload(add(owner, 0x40))) // owner.chainId
+      digest := keccak256(ptr, 0x80)
+    }
+  }
+}

--- a/src/libraries/Token.sol
+++ b/src/libraries/Token.sol
@@ -169,28 +169,4 @@ library Token {
       revert ErrUnsupportedStandard();
     }
   }
-
-  struct Owner {
-    address addr;
-    address tokenAddr;
-    uint256 chainId;
-  }
-
-  // keccak256("TokenOwner(address addr,address tokenAddr,uint256 chainId)");
-  bytes32 public constant OWNER_TYPE_HASH = 0x353bdd8d69b9e3185b3972e08b03845c0c14a21a390215302776a7a34b0e8764;
-
-  /**
-   * @dev Returns ownership struct hash.
-   */
-  function hash(Owner memory owner) internal pure returns (bytes32 digest) {
-    // keccak256(abi.encode(OWNER_TYPE_HASH, _owner.addr, _owner.tokenAddr, _owner.chainId))
-    assembly {
-      let ptr := mload(0x40)
-      mstore(ptr, OWNER_TYPE_HASH)
-      mstore(add(ptr, 0x20), mload(owner)) // _owner.addr
-      mstore(add(ptr, 0x40), mload(add(owner, 0x20))) // _owner.tokenAddr
-      mstore(add(ptr, 0x60), mload(add(owner, 0x40))) // _owner.chainId
-      digest := keccak256(ptr, 0x80)
-    }
-  }
 }

--- a/src/libraries/Token.sol
+++ b/src/libraries/Token.sol
@@ -71,8 +71,10 @@ library Token {
    */
   function validate(Info memory _info) internal pure {
     if (
-      !((_info.erc == Standard.ERC20 && _info.quantity > 0 && _info.id == 0) ||
-        (_info.erc == Standard.ERC721 && _info.quantity == 0))
+      !(
+        (_info.erc == Standard.ERC20 && _info.quantity > 0 && _info.id == 0)
+          || (_info.erc == Standard.ERC721 && _info.quantity == 0)
+      )
     ) revert ErrInvalidInfo();
   }
 
@@ -91,8 +93,10 @@ library Token {
       _success = _success && (_data.length == 0 || abi.decode(_data, (bool)));
     } else if (_info.erc == Standard.ERC721) {
       // bytes4(keccak256("transferFrom(address,address,uint256)"))
-      (_success, ) = _token.call(abi.encodeWithSelector(0x23b872dd, _from, _to, _info.id));
-    } else revert ErrUnsupportedStandard();
+      (_success,) = _token.call(abi.encodeWithSelector(0x23b872dd, _from, _to, _info.id));
+    } else {
+      revert ErrUnsupportedStandard();
+    }
 
     if (!_success) revert ErrTokenCouldNotTransferFrom(_info, _from, _to, _token);
   }
@@ -101,7 +105,7 @@ library Token {
    * @dev Transfers ERC721 token and returns the result.
    */
   function tryTransferERC721(address _token, address _to, uint256 _id) internal returns (bool _success) {
-    (_success, ) = _token.call(abi.encodeWithSelector(IERC721.transferFrom.selector, address(this), _to, _id));
+    (_success,) = _token.call(abi.encodeWithSelector(IERC721.transferFrom.selector, address(this), _to, _id));
   }
 
   /**
@@ -122,7 +126,9 @@ library Token {
       _success = tryTransferERC20(_token, _to, _info.quantity);
     } else if (_info.erc == Standard.ERC721) {
       _success = tryTransferERC721(_token, _to, _info.id);
-    } else revert ErrUnsupportedStandard();
+    } else {
+      revert ErrUnsupportedStandard();
+    }
 
     if (!_success) revert ErrTokenCouldNotTransfer(_info, _to, _token);
   }
@@ -133,12 +139,9 @@ library Token {
    * @notice Prioritizes transfer native token if the token is wrapped.
    *
    */
-  function handleAssetTransfer(
-    Info memory _info,
-    address payable _to,
-    address _token,
-    IWETH _wrappedNativeToken
-  ) internal {
+  function handleAssetTransfer(Info memory _info, address payable _to, address _token, IWETH _wrappedNativeToken)
+    internal
+  {
     bool _success;
     if (_token == address(_wrappedNativeToken)) {
       // Try sending the native token before transferring the wrapped token
@@ -151,7 +154,7 @@ library Token {
 
       if (_balance < _info.quantity) {
         // bytes4(keccak256("mint(address,uint256)"))
-        (_success, ) = _token.call(abi.encodeWithSelector(0x40c10f19, address(this), _info.quantity - _balance));
+        (_success,) = _token.call(abi.encodeWithSelector(0x40c10f19, address(this), _info.quantity - _balance));
         if (!_success) revert ErrERC20MintingFailed();
       }
 
@@ -159,10 +162,12 @@ library Token {
     } else if (_info.erc == Token.Standard.ERC721) {
       if (!tryTransferERC721(_token, _to, _info.id)) {
         // bytes4(keccak256("mint(address,uint256)"))
-        (_success, ) = _token.call(abi.encodeWithSelector(0x40c10f19, _to, _info.id));
+        (_success,) = _token.call(abi.encodeWithSelector(0x40c10f19, _to, _info.id));
         if (!_success) revert ErrERC721MintingFailed();
       }
-    } else revert ErrUnsupportedStandard();
+    } else {
+      revert ErrUnsupportedStandard();
+    }
   }
 
   struct Owner {

--- a/src/libraries/Transfer.sol
+++ b/src/libraries/Transfer.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./Token.sol";
+import "./LibTokenInfo.sol";
 import "./LibTokenOwner.sol";
 
 library Transfer {
   using ECDSA for bytes32;
   using LibTokenOwner for TokenOwner;
-  using Token for Token.Info;
+  using LibTokenInfo for TokenInfo;
 
   enum Kind {
     Deposit,
@@ -23,7 +23,7 @@ library Transfer {
     // Token address to deposit/withdraw
     // Value 0: native token
     address tokenAddr;
-    Token.Info info;
+    TokenInfo info;
   }
 
   /**
@@ -73,7 +73,7 @@ library Transfer {
     Kind kind;
     TokenOwner mainchain;
     TokenOwner ronin;
-    Token.Info info;
+    TokenInfo info;
   }
 
   // keccak256("Receipt(uint256 id,uint8 kind,TokenOwner mainchain,TokenOwner ronin,TokenInfo info)TokenInfo(uint8 erc,uint256 id,uint256 quantity)TokenOwner(address addr,address tokenAddr,uint256 chainId)");

--- a/src/libraries/Transfer.sol
+++ b/src/libraries/Transfer.sol
@@ -4,9 +4,12 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./Token.sol";
+import "./LibTokenOwner.sol";
 
 library Transfer {
   using ECDSA for bytes32;
+  using LibTokenOwner for TokenOwner;
+  using Token for Token.Info;
 
   enum Kind {
     Deposit,
@@ -68,8 +71,8 @@ library Transfer {
   struct Receipt {
     uint256 id;
     Kind kind;
-    Token.Owner mainchain;
-    Token.Owner ronin;
+    TokenOwner mainchain;
+    TokenOwner ronin;
     Token.Info info;
   }
 
@@ -80,9 +83,9 @@ library Transfer {
    * @dev Returns token info struct hash.
    */
   function hash(Receipt memory _receipt) internal pure returns (bytes32 digest) {
-    bytes32 hashedReceiptMainchain = Token.hash(_receipt.mainchain);
-    bytes32 hashedReceiptRonin = Token.hash(_receipt.ronin);
-    bytes32 hashedReceiptInfo = Token.hash(_receipt.info);
+    bytes32 hashedReceiptMainchain = _receipt.mainchain.hash();
+    bytes32 hashedReceiptRonin = _receipt.ronin.hash();
+    bytes32 hashedReceiptInfo = _receipt.info.hash();
 
     /*
      * return

--- a/src/libraries/Transfer.sol
+++ b/src/libraries/Transfer.sol
@@ -81,7 +81,7 @@ library Transfer {
   }
 
   // keccak256("Receipt(uint256 id,uint8 kind,TokenOwner mainchain,TokenOwner ronin,TokenInfo info)TokenInfo(uint8 erc,uint256 id,uint256 quantity)TokenOwner(address addr,address tokenAddr,uint256 chainId)");
-  bytes32 public constant TYPE_HASH = 0xb9d1fe7c9deeec5dc90a2f47ff1684239519f2545b2228d3d91fb27df3189eea;
+  bytes32 internal constant TYPE_HASH = 0xb9d1fe7c9deeec5dc90a2f47ff1684239519f2545b2228d3d91fb27df3189eea;
 
   /**
    * @dev Returns token info struct hash.

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -359,7 +359,7 @@ contract MainchainGatewayV3 is
       _token = getRoninToken(_request.tokenAddr);
       if (_token.erc != _request.info.erc) revert ErrInvalidTokenStandard();
 
-      _request.info.transferFrom(_requester, address(this), _request.tokenAddr);
+      _request.info.handleTransferFrom(_requester, address(this), _request.tokenAddr);
       // Withdraw if token is WETH
       if (_roninWeth == _request.tokenAddr) {
         IWETH(_roninWeth).withdraw(_request.info.quantity);

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -165,10 +165,10 @@ contract MainchainGatewayV3 is
       TokenInfo memory _withdrawInfo = _receipt.info;
       _withdrawInfo.quantity = _receipt.info.quantity - _feeInfo.quantity;
 
-      _feeInfo.handleAssetTransfer(payable(msg.sender), _token, wrappedNativeToken);
-      _withdrawInfo.handleAssetTransfer(payable(_receipt.mainchain.addr), _token, wrappedNativeToken);
+      _feeInfo.handleAssetOut(payable(msg.sender), _token, wrappedNativeToken);
+      _withdrawInfo.handleAssetOut(payable(_receipt.mainchain.addr), _token, wrappedNativeToken);
     } else {
-      _receipt.info.handleAssetTransfer(payable(_receipt.mainchain.addr), _token, wrappedNativeToken);
+      _receipt.info.handleAssetOut(payable(_receipt.mainchain.addr), _token, wrappedNativeToken);
     }
 
     emit Withdrew(_receiptHash, _receipt);
@@ -326,7 +326,7 @@ contract MainchainGatewayV3 is
     }
 
     _recordWithdrawal(_tokenAddr, _quantity);
-    _receipt.info.handleAssetTransfer(payable(_receipt.mainchain.addr), _tokenAddr, wrappedNativeToken);
+    _receipt.info.handleAssetOut(payable(_receipt.mainchain.addr), _tokenAddr, wrappedNativeToken);
     emit Withdrew(_receiptHash, _receipt);
   }
 

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -359,7 +359,7 @@ contract MainchainGatewayV3 is
       _token = getRoninToken(_request.tokenAddr);
       if (_token.erc != _request.info.erc) revert ErrInvalidTokenStandard();
 
-      _request.info.handleTransferFrom(_requester, address(this), _request.tokenAddr);
+      _request.info.handleAssetIn(_requester, _request.tokenAddr);
       // Withdraw if token is WETH
       if (_roninWeth == _request.tokenAddr) {
         IWETH(_roninWeth).withdraw(_request.info.quantity);

--- a/src/ronin/gateway/RoninGatewayV3.sol
+++ b/src/ronin/gateway/RoninGatewayV3.sol
@@ -401,7 +401,7 @@ contract RoninGatewayV3 is
     MappedToken memory _token = getMainchainToken(_request.tokenAddr, _chainId);
     if (_request.info.erc != _token.erc) revert ErrInvalidTokenStandard();
 
-    _request.info.handleTransferFrom(_requester, address(this), _request.tokenAddr);
+    _request.info.handleAssetIn(_requester, _request.tokenAddr);
     _storeAsReceipt(_request, _chainId, _requester, _token.tokenAddr);
   }
 

--- a/src/ronin/gateway/RoninGatewayV3.sol
+++ b/src/ronin/gateway/RoninGatewayV3.sol
@@ -401,7 +401,7 @@ contract RoninGatewayV3 is
     MappedToken memory _token = getMainchainToken(_request.tokenAddr, _chainId);
     if (_request.info.erc != _token.erc) revert ErrInvalidTokenStandard();
 
-    _request.info.transferFrom(_requester, address(this), _request.tokenAddr);
+    _request.info.handleTransferFrom(_requester, address(this), _request.tokenAddr);
     _storeAsReceipt(_request, _chainId, _requester, _token.tokenAddr);
   }
 

--- a/src/ronin/gateway/RoninGatewayV3.sol
+++ b/src/ronin/gateway/RoninGatewayV3.sol
@@ -24,7 +24,7 @@ contract RoninGatewayV3 is
   IRoninGatewayV3,
   HasContracts
 {
-  using Token for Token.Info;
+  using LibTokenInfo for TokenInfo;
   using Transfer for Transfer.Request;
   using Transfer for Transfer.Receipt;
   using IsolatedGovernance for IsolatedGovernance.Vote;
@@ -95,7 +95,7 @@ contract RoninGatewayV3 is
     // _packedNumbers[0]: chainIds
     // _packedNumbers[1]: minimumThresholds
     uint256[][2] calldata _packedNumbers,
-    Token.Standard[] calldata _standards
+    TokenStandard[] calldata _standards
   ) external virtual initializer {
     _setupRole(DEFAULT_ADMIN_ROLE, _roleSetter);
     _setThreshold(_numerator, _denominator);
@@ -288,7 +288,7 @@ contract RoninGatewayV3 is
     address[] calldata _roninTokens,
     address[] calldata _mainchainTokens,
     uint256[] calldata _chainIds,
-    Token.Standard[] calldata _standards
+    TokenStandard[] calldata _standards
   ) external onlyAdmin {
     if (_roninTokens.length == 0) revert ErrLengthMismatch(msg.sig);
     _mapTokens(_roninTokens, _mainchainTokens, _chainIds, _standards);
@@ -336,7 +336,7 @@ contract RoninGatewayV3 is
     address[] calldata _roninTokens,
     address[] calldata _mainchainTokens,
     uint256[] calldata _chainIds,
-    Token.Standard[] calldata _standards
+    TokenStandard[] calldata _standards
   ) internal {
     if (!(_roninTokens.length == _mainchainTokens.length && _roninTokens.length == _chainIds.length))
       revert ErrLengthMismatch(msg.sig);

--- a/src/ronin/gateway/RoninGatewayV3.sol
+++ b/src/ronin/gateway/RoninGatewayV3.sol
@@ -377,7 +377,7 @@ contract RoninGatewayV3 is
     emit DepositVoted(operator, id, receipt.mainchain.chainId, _receiptHash);
     if (_status == VoteStatus.Approved) {
       _proposal.status = VoteStatus.Executed;
-      receipt.info.handleAssetTransfer(payable(receipt.ronin.addr), receipt.ronin.tokenAddr, IWETH(address(0)));
+      receipt.info.handleAssetOut(payable(receipt.ronin.addr), receipt.ronin.tokenAddr, IWETH(address(0)));
       IBridgeTracking(getContract(ContractType.BRIDGE_TRACKING)).handleVoteApproved(
         IBridgeTracking.VoteKind.Deposit,
         receipt.id

--- a/test/bridge/integration/BaseIntegration.t.sol
+++ b/test/bridge/integration/BaseIntegration.t.sol
@@ -22,7 +22,7 @@ import { MockERC721 } from "@ronin/contracts/mocks/token/MockERC721.sol";
 import { MockWrappedToken } from "@ronin/contracts/mocks/token/MockWrappedToken.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 import { Proposal } from "@ronin/contracts/libraries/Proposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { IWETH } from "@ronin/contracts/interfaces/IWETH.sol";
 import { SignatureConsumer } from "@ronin/contracts/interfaces/consumers/SignatureConsumer.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";
@@ -232,13 +232,13 @@ contract BaseIntegration_Test is Base_Test {
     uint256 tokenNum = mainchainTokens.length; // reserve slot for ERC721Tokens
     uint256[] memory minimumThreshold = new uint256[](tokenNum);
     uint256[] memory chainIds = new uint256[](tokenNum);
-    Token.Standard[] memory standards = new Token.Standard[](tokenNum);
+    TokenStandard[] memory standards = new TokenStandard[](tokenNum);
     for (uint256 i; i < tokenNum; i++) {
       bool isERC721 = i == mainchainTokens.length - 1; // last item is ERC721
 
       minimumThreshold[i] = 20;
       chainIds[i] = block.chainid;
-      standards[i] = isERC721 ? Token.Standard.ERC721 : Token.Standard.ERC20;
+      standards[i] = isERC721 ? TokenStandard.ERC721 : TokenStandard.ERC20;
     }
 
     // Ronin Gateway V3
@@ -432,7 +432,7 @@ contract BaseIntegration_Test is Base_Test {
     uint256[] memory lockedThreshold = new uint256[](tokenNum);
     uint256[] memory unlockFeePercentages = new uint256[](tokenNum);
     uint256[] memory dailyWithdrawalLimits = new uint256[](tokenNum);
-    Token.Standard[] memory standards = new Token.Standard[](tokenNum);
+    TokenStandard[] memory standards = new TokenStandard[](tokenNum);
 
     for (uint256 i; i < tokenNum; i++) {
       bool isERC721 = i == mainchainTokens.length - 1; // last item is ERC721
@@ -441,7 +441,7 @@ contract BaseIntegration_Test is Base_Test {
       lockedThreshold[i] = 20;
       unlockFeePercentages[i] = 100_000;
       dailyWithdrawalLimits[i] = 12;
-      standards[i] = isERC721 ? Token.Standard.ERC721 : Token.Standard.ERC20;
+      standards[i] = isERC721 ? TokenStandard.ERC721 : TokenStandard.ERC20;
     }
 
     // Mainchain Gateway V3

--- a/test/bridge/integration/BaseIntegration.t.sol
+++ b/test/bridge/integration/BaseIntegration.t.sol
@@ -22,7 +22,7 @@ import { MockERC721 } from "@ronin/contracts/mocks/token/MockERC721.sol";
 import { MockWrappedToken } from "@ronin/contracts/mocks/token/MockWrappedToken.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 import { Proposal } from "@ronin/contracts/libraries/Proposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { IWETH } from "@ronin/contracts/interfaces/IWETH.sol";
 import { SignatureConsumer } from "@ronin/contracts/interfaces/consumers/SignatureConsumer.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";

--- a/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
+++ b/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
@@ -26,7 +26,13 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({
+        erc: TokenStandard.ERC20,
+        id: 0,
+        quantity: 100,
+        ids: new uint256[](0),
+        quantities: new uint256[](0)
+      })
     });
 
     for (uint256 i; i < 50; i++) {

--- a/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
+++ b/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { LibTokenOwner, TokenOwner } from "@ronin/contracts/libraries/LibTokenOwner.sol";
 import "../../BaseIntegration.t.sol";
 
@@ -26,7 +26,7 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
     });
 
     for (uint256 i; i < 50; i++) {

--- a/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
+++ b/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer } from "@ronin/contracts/libraries/Transfer.sol";
 import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenOwner, TokenOwner } from "@ronin/contracts/libraries/LibTokenOwner.sol";
 import "../../BaseIntegration.t.sol";
 
 contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
@@ -23,8 +24,8 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
     Transfer.Receipt memory sampleReceipt = Transfer.Receipt({
       id: 0,
       kind: Transfer.Kind.Deposit,
-      ronin: Token.Owner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: Token.Owner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
       info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
     });
 

--- a/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
+++ b/test/bridge/integration/bridge-manager/update-bridge-operator/updateOperator.RoninBridgeManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { LibTokenOwner, TokenOwner } from "@ronin/contracts/libraries/LibTokenOwner.sol";
 import "../../BaseIntegration.t.sol";
 
@@ -22,12 +22,15 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
     vm.deal(address(_bridgeReward), 10 ether);
     _newBridgeOperator = makeAddr("new-bridge-operator");
     Transfer.Receipt memory sampleReceipt = Transfer.Receipt({
-      id: 0,
-      kind: Transfer.Kind.Deposit,
-      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      manifest: Transfer.ReceiptManifest({
+        id: 0,
+        kind: Transfer.Kind.Deposit,
+        ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+        mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid })
+      }),
       info: TokenInfo({
         erc: TokenStandard.ERC20,
+        mode: Mode.Single,
         id: 0,
         quantity: 100,
         ids: new uint256[](0),
@@ -38,8 +41,8 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
     for (uint256 i; i < 50; i++) {
       first50Receipts.push(sampleReceipt);
       second50Receipts.push(sampleReceipt);
-      first50Receipts[i].id = id;
-      second50Receipts[i].id = id + 50;
+      first50Receipts[i].manifest.id = id;
+      second50Receipts[i].manifest.id = id + 50;
 
       id++;
     }
@@ -89,7 +92,7 @@ contract UpdateOperator_RoninBridgeManager_Test is BaseIntegration_Test {
   function _depositFor() internal {
     console.log(">> depositFor ....");
     Transfer.Receipt memory sampleReceipt = first50Receipts[0];
-    sampleReceipt.id = ++id + 50;
+    sampleReceipt.manifest.id = ++id + 50;
     for (uint256 i; i < _numOperatorsForVoteExecuted; i++) {
       console.log(" -> Operator vote:", _param.roninBridgeManager.bridgeOperators[i]);
       vm.prank(_param.roninBridgeManager.bridgeOperators[i]);

--- a/test/bridge/integration/mainchain-gateway/requestDepositFor.Batch.MainchainGatewayV3.t.sol
+++ b/test/bridge/integration/mainchain-gateway/requestDepositFor.Batch.MainchainGatewayV3.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import { console2 as console } from "forge-std/console2.sol";
+import { Transfer as LibTransfer } from "@ronin/contracts/libraries/Transfer.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+
+import "../BaseIntegration.t.sol";
+
+interface IERC721 {
+  event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+}
+
+interface IERC20 {
+  event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+contract RequestDepositFor_Batch_MainchainGatewayV3_Test is BaseIntegration_Test {
+  event DepositRequested(bytes32 receiptHash, LibTransfer.ReceiptManifest receipt);
+
+  using LibTransfer for LibTransfer.Request;
+  using LibTransfer for LibTransfer.Receipt;
+
+  LibTransfer.Request _depositRequest;
+
+  address _sender;
+  uint256 _quantity;
+
+  function setUp() public virtual override {
+    super.setUp();
+
+    _sender = makeAddr("sender");
+    _quantity = 10;
+
+    _depositRequest.recipientAddr = makeAddr("recipient");
+    _depositRequest.tokenAddr = address(0);
+    _depositRequest.info.erc = TokenStandard.ERC20;
+    _depositRequest.info.id = 0;
+    _depositRequest.info.quantity = _quantity;
+
+    vm.deal(_sender, 10 ether);
+  }
+
+  // deposit erc721 in batch (2 ids), both success
+  function test_depositERC721Batch_Success() public {
+    uint256 tokenId1 = 22;
+    uint256 tokenId2 = 23;
+    _mainchainMockERC721.mint(_sender, tokenId1);
+    _mainchainMockERC721.mint(_sender, tokenId2);
+    vm.startPrank(_sender);
+    _mainchainMockERC721.approve(address(_mainchainGatewayV3), tokenId1);
+    _mainchainMockERC721.approve(address(_mainchainGatewayV3), tokenId2);
+    vm.stopPrank();
+
+    _depositRequest.tokenAddr = address(_mainchainMockERC721);
+    _depositRequest.info.erc = TokenStandard.ERC721;
+    _depositRequest.info.mode = Mode.Batch;
+    _depositRequest.info.id = 0;
+    _depositRequest.info.quantity = 0;
+    _depositRequest.info.ids = new uint256[](2);
+    _depositRequest.info.ids[0] = tokenId1;
+    _depositRequest.info.ids[1] = tokenId2;
+    _depositRequest.info.quantities = new uint256[](2);
+
+    LibTransfer.Receipt memory receipt = _depositRequest.into_deposit_receipt(
+      _sender, _mainchainGatewayV3.depositCount(), address(_roninMockERC721), block.chainid
+    );
+    vm.expectEmit(address(_mainchainGatewayV3));
+    emit DepositRequested(receipt.hash(), receipt.manifest);
+
+    assertEq(_mainchainMockERC721.ownerOf(tokenId1), _sender);
+    assertEq(_mainchainMockERC721.ownerOf(tokenId2), _sender);
+
+    vm.prank(_sender);
+    _mainchainGatewayV3.requestDepositFor(_depositRequest);
+
+    assertEq(_mainchainMockERC721.ownerOf(tokenId1), address(_mainchainGatewayV3));
+    assertEq(_mainchainMockERC721.ownerOf(tokenId2), address(_mainchainGatewayV3));
+    assertEq(_mainchainGatewayV3.depositCount(), 1);
+  }
+}

--- a/test/bridge/integration/mainchain-gateway/requestDepositFor.MainchainGatewayV3.t.sol
+++ b/test/bridge/integration/mainchain-gateway/requestDepositFor.MainchainGatewayV3.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer as LibTransfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 
 import "../BaseIntegration.t.sol";
 
@@ -16,7 +16,7 @@ interface IERC20 {
 }
 
 contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
-  event DepositRequested(bytes32 receiptHash, LibTransfer.Receipt receipt);
+  event DepositRequested(bytes32 receiptHash, LibTransfer.ReceiptManifest receipt);
 
   using LibTransfer for LibTransfer.Request;
   using LibTransfer for LibTransfer.Receipt;
@@ -35,6 +35,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
     _depositRequest.recipientAddr = makeAddr("recipient");
     _depositRequest.tokenAddr = address(0);
     _depositRequest.info.erc = TokenStandard.ERC20;
+    _depositRequest.info.mode = Mode.Single;
     _depositRequest.info.id = 0;
     _depositRequest.info.quantity = _quantity;
 
@@ -52,7 +53,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
     LibTransfer.Receipt memory receipt = cachedRequest.into_deposit_receipt(
       _sender, _mainchainGatewayV3.depositCount(), address(_roninWeth), block.chainid
     );
-    emit DepositRequested(receipt.hash(), receipt);
+    emit DepositRequested(receipt.hash(), receipt.manifest);
 
     vm.prank(_sender);
     _mainchainGatewayV3.requestDepositFor{ value: _quantity }(_depositRequest);
@@ -73,7 +74,8 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
     LibTransfer.Receipt memory receipt = _depositRequest.into_deposit_receipt(
       _sender, _mainchainGatewayV3.depositCount(), address(_roninAxs), block.chainid
     );
-    emit DepositRequested(receipt.hash(), receipt);
+
+    emit DepositRequested(receipt.hash(), receipt.manifest);
 
     vm.prank(_sender);
     _mainchainGatewayV3.requestDepositFor(_depositRequest);
@@ -98,7 +100,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
       _sender, _mainchainGatewayV3.depositCount(), address(_roninMockERC721), block.chainid
     );
     vm.expectEmit(address(_mainchainGatewayV3));
-    emit DepositRequested(receipt.hash(), receipt);
+    emit DepositRequested(receipt.hash(), receipt.manifest);
 
     assertEq(_mainchainMockERC721.ownerOf(tokenId), _sender);
 
@@ -123,7 +125,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
       _sender, _mainchainGatewayV3.depositCount(), address(_roninWeth), block.chainid
     );
     vm.expectEmit(address(_mainchainGatewayV3));
-    emit DepositRequested(receipt.hash(), receipt);
+    emit DepositRequested(receipt.hash(), receipt.manifest);
 
     assertEq(address(_mainchainWeth).balance, _quantity);
 

--- a/test/bridge/integration/mainchain-gateway/requestDepositFor.MainchainGatewayV3.t.sol
+++ b/test/bridge/integration/mainchain-gateway/requestDepositFor.MainchainGatewayV3.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer as LibTransfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 
 import "../BaseIntegration.t.sol";
 
@@ -34,7 +34,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
 
     _depositRequest.recipientAddr = makeAddr("recipient");
     _depositRequest.tokenAddr = address(0);
-    _depositRequest.info.erc = Token.Standard.ERC20;
+    _depositRequest.info.erc = TokenStandard.ERC20;
     _depositRequest.info.id = 0;
     _depositRequest.info.quantity = _quantity;
 
@@ -90,7 +90,7 @@ contract RequestDepositFor_MainchainGatewayV3_Test is BaseIntegration_Test {
     _mainchainMockERC721.approve(address(_mainchainGatewayV3), tokenId);
 
     _depositRequest.tokenAddr = address(_mainchainMockERC721);
-    _depositRequest.info.erc = Token.Standard.ERC721;
+    _depositRequest.info.erc = TokenStandard.ERC721;
     _depositRequest.info.id = tokenId;
     _depositRequest.info.quantity = 0;
 

--- a/test/bridge/integration/mainchain-gateway/submitWithdrawal.MainchainGatewayV3.t.sol
+++ b/test/bridge/integration/mainchain-gateway/submitWithdrawal.MainchainGatewayV3.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer as LibTransfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { SignatureConsumer } from "@ronin/contracts/interfaces/consumers/SignatureConsumer.sol";
 import { IMainchainGatewayV3 } from "@ronin/contracts/interfaces/IMainchainGatewayV3.sol";
 import "../BaseIntegration.t.sol";
@@ -43,7 +43,7 @@ contract SubmitWithdrawal_MainchainGatewayV3_Test is BaseIntegration_Test {
     _withdrawalReceipt.mainchain.addr = makeAddr("recipient");
     _withdrawalReceipt.mainchain.tokenAddr = address(_mainchainWeth);
     _withdrawalReceipt.mainchain.chainId = block.chainid;
-    _withdrawalReceipt.info.erc = Token.Standard.ERC20;
+    _withdrawalReceipt.info.erc = TokenStandard.ERC20;
     _withdrawalReceipt.info.id = 0;
     _withdrawalReceipt.info.quantity = 10;
 
@@ -187,7 +187,7 @@ contract SubmitWithdrawal_MainchainGatewayV3_Test is BaseIntegration_Test {
     _withdrawalReceipt.mainchain.tokenAddr = address(_mainchainMockERC721);
     _withdrawalReceipt.ronin.tokenAddr = address(_roninMockERC721);
     _withdrawalReceipt.info.id = tokenId;
-    _withdrawalReceipt.info.erc = Token.Standard.ERC721;
+    _withdrawalReceipt.info.erc = TokenStandard.ERC721;
     _withdrawalReceipt.info.quantity = 0;
 
     SignatureConsumer.Signature[] memory signatures =
@@ -215,7 +215,7 @@ contract SubmitWithdrawal_MainchainGatewayV3_Test is BaseIntegration_Test {
     _withdrawalReceipt.mainchain.tokenAddr = address(_mainchainMockERC721);
     _withdrawalReceipt.ronin.tokenAddr = address(_roninMockERC721);
     _withdrawalReceipt.info.id = tokenId;
-    _withdrawalReceipt.info.erc = Token.Standard.ERC721;
+    _withdrawalReceipt.info.erc = TokenStandard.ERC721;
     _withdrawalReceipt.info.quantity = 0;
 
     SignatureConsumer.Signature[] memory signatures =

--- a/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
+++ b/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
@@ -26,12 +26,15 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
   function test_RevertWhen_InteractWithGateway_AfterPause() public {
     test_EmergencyPause_RoninGatewayV3();
     Transfer.Receipt memory receipt = Transfer.Receipt({
-      id: 0,
-      kind: Transfer.Kind.Deposit,
-      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      manifest: Transfer.ReceiptManifest({
+        id: 0,
+        kind: Transfer.Kind.Deposit,
+        ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+        mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid })
+      }),
       info: TokenInfo({
         erc: TokenStandard.ERC20,
+        mode: Mode.Single,
         id: 0,
         quantity: 100,
         ids: new uint256[](0),
@@ -69,12 +72,15 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
   function test_InteractWithGateway_AfterUnpause() public {
     test_EmergencyUnpause_RoninGatewayV3();
     Transfer.Receipt memory receipt = Transfer.Receipt({
-      id: 0,
-      kind: Transfer.Kind.Deposit,
-      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      manifest: Transfer.ReceiptManifest({
+        id: 0,
+        kind: Transfer.Kind.Deposit,
+        ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+        mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid })
+      }),
       info: TokenInfo({
         erc: TokenStandard.ERC20,
+        mode: Mode.Single,
         id: 0,
         quantity: 100,
         ids: new uint256[](0),

--- a/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
+++ b/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 import { Transfer } from "@ronin/contracts/libraries/Transfer.sol";
 import { GatewayV3 } from "@ronin/contracts/extensions/GatewayV3.sol";
+import { LibTokenOwner, TokenOwner } from "@ronin/contracts/libraries/LibTokenOwner.sol";
 import "../BaseIntegration.t.sol";
 
 contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
@@ -27,8 +28,8 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
     Transfer.Receipt memory receipt = Transfer.Receipt({
       id: 0,
       kind: Transfer.Kind.Deposit,
-      ronin: Token.Owner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: Token.Owner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
       info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
     });
 
@@ -64,8 +65,8 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
     Transfer.Receipt memory receipt = Transfer.Receipt({
       id: 0,
       kind: Transfer.Kind.Deposit,
-      ronin: Token.Owner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: Token.Owner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
       info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
     });
 

--- a/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
+++ b/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
@@ -30,7 +30,13 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({
+        erc: TokenStandard.ERC20,
+        id: 0,
+        quantity: 100,
+        ids: new uint256[](0),
+        quantities: new uint256[](0)
+      })
     });
 
     vm.expectRevert("Pausable: paused");
@@ -67,7 +73,13 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({
+        erc: TokenStandard.ERC20,
+        id: 0,
+        quantity: 100,
+        ids: new uint256[](0),
+        quantities: new uint256[](0)
+      })
     });
 
     uint256 numOperatorsForVoteExecuted =

--- a/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
+++ b/test/bridge/integration/pause-enforcer/emergencyAction.PauseEnforcer.t.sol
@@ -30,7 +30,7 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
     });
 
     vm.expectRevert("Pausable: paused");
@@ -67,7 +67,7 @@ contract EmergencyAction_PauseEnforcer_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
     });
 
     uint256 numOperatorsForVoteExecuted =

--- a/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
+++ b/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
@@ -27,7 +27,13 @@ contract DepositVote_RoninGatewayV3_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({
+        erc: TokenStandard.ERC20,
+        id: 0,
+        quantity: 100,
+        ids: new uint256[](0),
+        quantities: new uint256[](0)
+      })
     });
 
     _depositReceipts.push(receipt);

--- a/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
+++ b/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
@@ -8,6 +8,7 @@ import { ContractType } from "@ronin/contracts/utils/ContractType.sol";
 import { IsolatedGovernance } from "@ronin/contracts/libraries/IsolatedGovernance.sol";
 import { VoteStatusConsumer } from "@ronin/contracts/interfaces/consumers/VoteStatusConsumer.sol";
 import { MockRoninGatewayV3Extended } from "@ronin/contracts/mocks/ronin/MockRoninGatewayV3Extended.sol";
+import { LibTokenOwner, TokenOwner } from "@ronin/contracts/libraries/LibTokenOwner.sol";
 import "../BaseIntegration.t.sol";
 
 contract DepositVote_RoninGatewayV3_Test is BaseIntegration_Test {
@@ -24,8 +25,8 @@ contract DepositVote_RoninGatewayV3_Test is BaseIntegration_Test {
     Transfer.Receipt memory receipt = Transfer.Receipt({
       id: 0,
       kind: Transfer.Kind.Deposit,
-      ronin: Token.Owner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
-      mainchain: Token.Owner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
+      ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
+      mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
       info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
     });
 

--- a/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
+++ b/test/bridge/integration/ronin-gateway/depositVote.RoninGatewayV3.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.19;
 
 import { console2 as console } from "forge-std/console2.sol";
 import { Transfer } from "@ronin/contracts/libraries/Transfer.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { ContractType } from "@ronin/contracts/utils/ContractType.sol";
 import { IsolatedGovernance } from "@ronin/contracts/libraries/IsolatedGovernance.sol";
 import { VoteStatusConsumer } from "@ronin/contracts/interfaces/consumers/VoteStatusConsumer.sol";
@@ -27,7 +27,7 @@ contract DepositVote_RoninGatewayV3_Test is BaseIntegration_Test {
       kind: Transfer.Kind.Deposit,
       ronin: TokenOwner({ addr: makeAddr("recipient"), tokenAddr: address(_roninWeth), chainId: block.chainid }),
       mainchain: TokenOwner({ addr: makeAddr("requester"), tokenAddr: address(_mainchainWeth), chainId: block.chainid }),
-      info: Token.Info({ erc: Token.Standard.ERC20, id: 0, quantity: 100 })
+      info: TokenInfo({ erc: TokenStandard.ERC20, id: 0, quantity: 100 })
     });
 
     _depositReceipts.push(receipt);

--- a/test/helpers/ProposalUtils.t.sol
+++ b/test/helpers/ProposalUtils.t.sol
@@ -5,7 +5,7 @@ import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { Test } from "forge-std/Test.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 import { Proposal } from "@ronin/contracts/libraries/Proposal.sol";
-import { Token } from "@ronin/contracts/libraries/Token.sol";
+import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";
 import { SignatureConsumer } from "@ronin/contracts/interfaces/consumers/SignatureConsumer.sol";
 import { Utils } from "script/utils/Utils.sol";

--- a/test/helpers/ProposalUtils.t.sol
+++ b/test/helpers/ProposalUtils.t.sol
@@ -5,7 +5,7 @@ import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { Test } from "forge-std/Test.sol";
 import { GlobalProposal } from "@ronin/contracts/libraries/GlobalProposal.sol";
 import { Proposal } from "@ronin/contracts/libraries/Proposal.sol";
-import { LibTokenInfo, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
+import { LibTokenInfo, Mode, TokenInfo, TokenStandard } from "@ronin/contracts/libraries/LibTokenInfo.sol";
 import { Ballot } from "@ronin/contracts/libraries/Ballot.sol";
 import { SignatureConsumer } from "@ronin/contracts/interfaces/consumers/SignatureConsumer.sol";
 import { Utils } from "script/utils/Utils.sol";


### PR DESCRIPTION
### Description

#### Features
- Support ERC721Batch
- Support ERC1155Batch

#### Impl changes
- Split `Owner` and `Info` into two separate libs
- Rename the exposed methods in lib to `handleAssetIn/Out`
- Add different hash for Batch request, reserve the legacy hash for Single request for backward-compatible
- Minor refactor and code convention

#### TODO
- [ ] Benchmark gas in batch request and restrict the number of `ids` in a request.


### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
