### PR TITLE
fix(BridgeReward): add addition gas stipend config to ensure sufficient gas after London hardfork

### DIFF
--- a/src/extensions/RONTransferHelper.sol
+++ b/src/extensions/RONTransferHelper.sol
@@ -47,6 +47,12 @@ abstract contract RONTransferHelper {
    * @dev Same purpose with {_unsafeSendRONLimitGas(address,uin256)} but containing gas limit stipend forwarded in the call.
    */
   function _unsafeSendRONLimitGas(address payable recipient, uint256 amount, uint256 gas) internal returns (bool success) {
+    // When msg.value = 0, the forwarding gas will not be auto-added 2300.
+    // We add an extra 2300 to make sure all calls will have the same amount of gas.
+    if (amount == 0) {
+      gas += 2300;
+    }
+
     (success,) = recipient.call{ value: amount, gas: gas }("");
   }
 }

--- a/src/interfaces/bridge/IBridgeReward.sol
+++ b/src/interfaces/bridge/IBridgeReward.sol
@@ -6,6 +6,11 @@ import { IBridgeRewardEvents } from "./events/IBridgeRewardEvents.sol";
 
 interface IBridgeReward is IBridgeRewardEvents {
   /**
+   * @dev Configuration of gas stipend to ensure sufficient gas after London Hardfork.
+   */
+  function DEFAULT_ADDITION_GAS() external view returns (uint256);
+  
+  /**
    * @dev This function allows bridge operators to manually synchronize the reward for a given period length.
    * @param periodCount The length of the reward period for which synchronization is requested.
    */

--- a/src/ronin/gateway/BridgeReward.sol
+++ b/src/ronin/gateway/BridgeReward.sol
@@ -16,7 +16,7 @@ import { TUint256Slot } from "../../types/Types.sol";
 import { ErrSyncTooFarPeriod, ErrInvalidArguments, ErrLengthMismatch, ErrUnauthorizedCall } from "../../utils/CommonErrors.sol";
 
 contract BridgeReward is IBridgeReward, BridgeTrackingHelper, HasContracts, RONTransferHelper, Initializable {
-  /// @dev Configuration of gas stipend to ensure sufficient gas after the London Hardfork
+  /// @inheritdoc IBridgeReward
   uint256 public constant DEFAULT_ADDITION_GAS = 6200;
   /// @dev value is equal to keccak256("@ronin.dpos.gateway.BridgeReward.rewardInfo.slot") - 1
   bytes32 private constant $_REWARD_INFO = 0x518cfd198acbffe95e740cfce1af28a3f7de51f0d784893d3d72c5cc59d7062a;

--- a/src/ronin/gateway/BridgeReward.sol
+++ b/src/ronin/gateway/BridgeReward.sol
@@ -16,6 +16,8 @@ import { TUint256Slot } from "../../types/Types.sol";
 import { ErrSyncTooFarPeriod, ErrInvalidArguments, ErrLengthMismatch, ErrUnauthorizedCall } from "../../utils/CommonErrors.sol";
 
 contract BridgeReward is IBridgeReward, BridgeTrackingHelper, HasContracts, RONTransferHelper, Initializable {
+  /// @dev Configuration of gas stipend to ensure sufficient gas after the London Hardfork
+  uint256 public constant DEFAULT_ADDITION_GAS = 6200;
   /// @dev value is equal to keccak256("@ronin.dpos.gateway.BridgeReward.rewardInfo.slot") - 1
   bytes32 private constant $_REWARD_INFO = 0x518cfd198acbffe95e740cfce1af28a3f7de51f0d784893d3d72c5cc59d7062a;
   /// @dev value is equal to keccak256("@ronin.dpos.gateway.BridgeReward.rewardPerPeriod.slot") - 1
@@ -316,7 +318,7 @@ contract BridgeReward is IBridgeReward, BridgeTrackingHelper, HasContracts, RONT
       return false;
     }
 
-    if (_unsafeSendRONLimitGas({ recipient: payable(operator), amount: reward, gas: 0 })) {
+    if (_unsafeSendRONLimitGas({ recipient: payable(operator), amount: reward, gas: DEFAULT_ADDITION_GAS })) {
       _iRewardInfo.claimed += reward;
       emit BridgeRewardScattered(period, operator, reward);
       return true;


### PR DESCRIPTION
### Description
This PR adds gas stipend configuration to ensure sufficient gas when transferring RON to multisig wallet after `aaron` hardfork which applies `london` evm hardfork changes.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
