### PR TITLE
fix(WBTC): fix decimals to match with WBTC on ethereum

### DIFF
--- a/src/tokens/erc20/WBTC.sol
+++ b/src/tokens/erc20/WBTC.sol
@@ -18,6 +18,13 @@ contract WBTC is ERC20PresetMinterPauser {
     _revokeRole(PAUSER_ROLE, _msgSender());
   }
 
+  /**
+   * @inheritdoc ERC20
+   */
+  function decimals() public view virtual override returns (uint8) {
+    return 8;
+  }
+
   function _beforeTokenTransfer(address from, address to, uint256 amount) internal override(ERC20PresetMinterPauser) {
     if (to == address(0)) {
       if (_msgSender() != GATEWAY_ADDRESS) {


### PR DESCRIPTION
### Description
This PR fixes decimals value mismatch between [WBTC on ethereum](https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599#readContract#F4) and ronin chain.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
