### PR TITLE
script: update decimal config wbtc

### DIFF
--- a/script/20240716-upgrade-v3.2.0-mainnet/wbtc-threshold.s.sol
+++ b/script/20240716-upgrade-v3.2.0-mainnet/wbtc-threshold.s.sol
@@ -5,11 +5,11 @@ contract Migration__MapToken_WBTC_Threshold {
   address _wbtcRoninToken = address(0x7E73630F81647bCFD7B1F2C04c1C662D17d4577e); // https://app.roninchain.com/address/0x7e73630f81647bcfd7b1f2c04c1c662d17d4577e
   address _wbtcMainchainToken = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599); // https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599
 
-  // The decimal of WBTC token is 18
-  uint256 _wbtcHighTierThreshold = 17 ether;
-  uint256 _wbtcLockedThreshold = 34 ether;
-  uint256 _wbtcDailyWithdrawalLimit = 42 ether;
-  uint256 _wbtcMinThreshold = 0.000167 ether;
+  // The decimal of WBTC token is 8
+  uint256 _wbtcHighTierThreshold = 17 * 10 ** 8;
+  uint256 _wbtcLockedThreshold = 34 * 10 ** 8;
+  uint256 _wbtcDailyWithdrawalLimit = 42 * 10 ** 8;
+  uint256 _wbtcMinThreshold = 0.000167 * 10 ** 8;
 
   // The MAX_PERCENTAGE is 100_0000
   uint256 _wbtcUnlockFeePercentages = 10; // 0.001%. Max percentage is 1e6 so 10 is 0.001% (`10 / 1e6 = 0.001 * 100`)


### PR DESCRIPTION
### Description
This PR updates correct decimal value of ronin's WBTC for threshold configs.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
