### PR TITLE
fix(MainchainGatewayV3): more checks on invalid signer and null total weight

### DIFF
--- a/src/extensions/GatewayV3.sol
+++ b/src/extensions/GatewayV3.sol
@@ -6,6 +6,11 @@ import "../interfaces/IQuorum.sol";
 import "./collections/HasProxyAdmin.sol";
 
 abstract contract GatewayV3 is HasProxyAdmin, Pausable, IQuorum {
+  /**
+   * @dev Error indicating that `_minimumVoteWeight` is returning 0.
+   */
+  error ErrNullMinVoteWeightProvided(bytes4 msgSig);
+
   uint256 internal _num;
   uint256 internal _denom;
 
@@ -78,11 +83,14 @@ abstract contract GatewayV3 is HasProxyAdmin, Pausable, IQuorum {
    *
    */
   function _setThreshold(uint256 num, uint256 denom) internal virtual {
-    if (num > denom) revert ErrInvalidThreshold(msg.sig);
+    if (num > denom || denom == 0 || num == 0) revert ErrInvalidThreshold(msg.sig);
+
     uint256 prevNum = _num;
     uint256 prevDenom = _denom;
+
     _num = num;
     _denom = denom;
+
     unchecked {
       emit ThresholdUpdated(nonce++, num, denom, prevNum, prevDenom);
     }
@@ -91,8 +99,9 @@ abstract contract GatewayV3 is HasProxyAdmin, Pausable, IQuorum {
   /**
    * @dev Returns minimum vote weight.
    */
-  function _minimumVoteWeight(uint256 _totalWeight) internal view virtual returns (uint256) {
-    return (_num * _totalWeight + _denom - 1) / _denom;
+  function _minimumVoteWeight(uint256 _totalWeight) internal view virtual returns (uint256 minVoteWeight) {
+    minVoteWeight = (_num * _totalWeight + _denom - 1) / _denom;
+    if (minVoteWeight == 0) revert ErrNullMinVoteWeightProvided(msg.sig);
   }
 
   /**

--- a/src/extensions/WithdrawalLimitation.sol
+++ b/src/extensions/WithdrawalLimitation.sol
@@ -6,6 +6,8 @@ import "./GatewayV3.sol";
 abstract contract WithdrawalLimitation is GatewayV3 {
   /// @dev Error of invalid percentage.
   error ErrInvalidPercentage();
+  /// @dev Error thrown when the high-tier vote weight threshold is `0`.
+  error ErrNullHighTierVoteWeightProvided(bytes4 msgSig);
 
   /// @dev Emitted when the high-tier vote weight threshold is updated
   event HighTierVoteWeightThresholdUpdated(
@@ -163,7 +165,7 @@ abstract contract WithdrawalLimitation is GatewayV3 {
    *
    */
   function _setHighTierVoteWeightThreshold(uint256 _numerator, uint256 _denominator) internal returns (uint256 _previousNum, uint256 _previousDenom) {
-    if (_numerator > _denominator) revert ErrInvalidThreshold(msg.sig);
+    if (_numerator > _denominator || _numerator == 0 || _denominator == 0) revert ErrInvalidThreshold(msg.sig);
 
     _previousNum = _highTierVWNum;
     _previousDenom = _highTierVWDenom;
@@ -316,8 +318,9 @@ abstract contract WithdrawalLimitation is GatewayV3 {
   /**
    * @dev Returns high-tier vote weight.
    */
-  function _highTierVoteWeight(uint256 _totalWeight) internal view virtual returns (uint256) {
-    return (_highTierVWNum * _totalWeight + _highTierVWDenom - 1) / _highTierVWDenom;
+  function _highTierVoteWeight(uint256 _totalWeight) internal view virtual returns (uint256 highTierVW) {
+    highTierVW = (_highTierVWNum * _totalWeight + _highTierVWDenom - 1) / _highTierVWDenom;
+    if (highTierVW == 0) revert ErrNullHighTierVoteWeightProvided(msg.sig);
   }
 
   /**

--- a/src/interfaces/IMainchainGatewayV3.sol
+++ b/src/interfaces/IMainchainGatewayV3.sol
@@ -27,6 +27,16 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
    */
   error ErrQueryForInsufficientVoteWeight();
 
+  /**
+   * @dev Error indicating that the recovered signer from the signature has invalid vote weight.
+   */
+  error ErrInvalidSignature(address signer, uint256 weight, Signature sig);
+
+  /**
+   * @dev Error indicating that the total weight provided is null.
+   */
+  error ErrNullTotalWeightProvided(bytes4 msgSig);
+
   /// @dev Emitted when the deposit is requested
   event DepositRequested(bytes32 receiptHash, Transfer.Receipt receipt);
   /// @dev Emitted when the assets are withdrawn
@@ -41,7 +51,7 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   event WithdrawalUnlocked(bytes32 receiptHash, Transfer.Receipt receipt);
 
   /**
-   * @dev Returns the domain seperator.
+   * @dev Returns the domain separator.
    */
   function DOMAIN_SEPARATOR() external view returns (bytes32);
 

--- a/src/interfaces/IMainchainGatewayV3.sol
+++ b/src/interfaces/IMainchainGatewayV3.sol
@@ -30,7 +30,7 @@ interface IMainchainGatewayV3 is SignatureConsumer, MappedTokenConsumer {
   /**
    * @dev Error indicating that the recovered signer from the signature has invalid vote weight.
    */
-  error ErrInvalidSignature(address signer, uint256 weight, Signature sig);
+  error ErrInvalidSigner(address signer, uint256 weight, Signature sig);
 
   /**
    * @dev Error indicating that the total weight provided is null.

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.23;
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IBridgeManager } from "../interfaces/bridge/IBridgeManager.sol";
 import { IBridgeManagerCallback } from "../interfaces/bridge/IBridgeManagerCallback.sol";
 import { HasContracts, ContractType } from "../extensions/collections/HasContracts.sol";
@@ -309,16 +310,19 @@ contract MainchainGatewayV3 is
       address signer;
       address lastSigner;
       Signature memory sig;
-      uint256 weight;
+      uint256 accWeight;
       for (uint256 i; i < signatures.length; i++) {
         sig = signatures[i];
-        signer = ecrecover(receiptDigest, sig.v, sig.r, sig.s);
+        signer = ECDSA.recover({ hash: receiptDigest, v: sig.v, r: sig.r, s: sig.s });
         if (lastSigner >= signer) revert ErrInvalidOrder(msg.sig);
 
         lastSigner = signer;
 
-        weight += _getWeight(signer);
-        if (weight >= minimumWeight) {
+        uint256 w = _getWeight(signer);
+        if (w == 0) revert ErrInvalidSignature(signer, w, sig);
+
+        accWeight += w;
+        if (accWeight >= minimumWeight) {
           passed = true;
           break;
         }
@@ -398,7 +402,7 @@ contract MainchainGatewayV3 is
   }
 
   /**
-   * @dev Update domain seperator.
+   * @dev Update domain separator.
    */
   function _updateDomainSeparator() internal {
     /*
@@ -432,9 +436,9 @@ contract MainchainGatewayV3 is
    * Emits the `WrappedNativeTokenContractUpdated` event.
    *
    */
-  function _setWrappedNativeTokenContract(IWETH _wrapedToken) internal {
-    wrappedNativeToken = _wrapedToken;
-    emit WrappedNativeTokenContractUpdated(_wrapedToken);
+  function _setWrappedNativeTokenContract(IWETH _wrappedToken) internal {
+    wrappedNativeToken = _wrappedToken;
+    emit WrappedNativeTokenContractUpdated(_wrappedToken);
   }
 
   /**
@@ -461,8 +465,9 @@ contract MainchainGatewayV3 is
   /**
    * @inheritdoc GatewayV3
    */
-  function _getTotalWeight() internal view override returns (uint256) {
-    return _totalOperatorWeight;
+  function _getTotalWeight() internal view override returns (uint256 totalWeight) {
+    totalWeight = _totalOperatorWeight;
+    if (totalWeight == 0) revert ErrNullTotalWeightProvided(msg.sig);
   }
 
   /**

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -310,7 +310,7 @@ contract MainchainGatewayV3 is
       address signer;
       address lastSigner;
       Signature memory sig;
-      uint256 accWeight;
+      uint256 accumWeight;
       for (uint256 i; i < signatures.length; i++) {
         sig = signatures[i];
         signer = ECDSA.recover({ hash: receiptDigest, v: sig.v, r: sig.r, s: sig.s });
@@ -321,8 +321,8 @@ contract MainchainGatewayV3 is
         uint256 w = _getWeight(signer);
         if (w == 0) revert ErrInvalidSignature(signer, w, sig);
 
-        accWeight += w;
-        if (accWeight >= minimumWeight) {
+        accumWeight += w;
+        if (accumWeight >= minimumWeight) {
           passed = true;
           break;
         }

--- a/src/mainchain/MainchainGatewayV3.sol
+++ b/src/mainchain/MainchainGatewayV3.sol
@@ -319,7 +319,7 @@ contract MainchainGatewayV3 is
         lastSigner = signer;
 
         uint256 w = _getWeight(signer);
-        if (w == 0) revert ErrInvalidSignature(signer, w, sig);
+        if (w == 0) revert ErrInvalidSigner(signer, w, sig);
 
         accumWeight += w;
         if (accumWeight >= minimumWeight) {


### PR DESCRIPTION
### Description
This PR enhances `MainchainGatewayV3::submitWithdrawal` function by:
- Revert when `totalVoteWeight` is `0`.
- Revert when `minimumVoteWeight` is `0`.
- Revert when `ECDSA` v, r, s are non-unique (malleable).
- Revert when signer weight is `0`.

### Checklist
- [x] I have clearly commented on all the main functions following the [NatSpec Format](https://docs.soliditylang.org/en/v0.8.0/natspec-format.html)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
